### PR TITLE
Update dfflegalize scheme

### DIFF
--- a/src/synth_fpga.cc
+++ b/src/synth_fpga.cc
@@ -1014,7 +1014,7 @@ struct SynthFpgaPass : public ScriptPass
     for (auto it : dff_features->data_array) {
           JsonNode *dff_mode = it;
           if (dff_mode->type != 'S') {
-              log_error("Array associated to DFF 'features' must be contain only strings.\n");
+              log_error("Array associated to DFF 'features' must contain only strings.\n");
           }
 	  string dff_mode_str = dff_mode->data_string;
 


### PR DESCRIPTION
The approach now is to pass exactly the list of yosys primitives that are techmapped by an architecture's flop techmap file, where the list is passed in via the config file.

The "features" portion of the config is left intact for backward compatibility, although it's less clear now whether we still need it.