### PR TITLE
No red due to placeholder .md formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ yosys > synth_fpga -config <configuration file>
 
 The configuration format is still work in progress. An draft format specification is shown below.
 
-```json
+```
 {
         "version": <int, version of file schema, current version is 1>,
         "partname": <str, name of the fpga part>,


### PR DESCRIPTION
Fix issue where README.md displays red, errored-out text.