### PR TITLE
add yosys version warning to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,12 @@ set(OUTPUT_NAME "wildebeest")
 
 find_package(Yosys)
 
+string(FIND ${YOSYS_VERSION} "+" YOSYS_CHECK)
+if (${YOSYS_CHECK} EQUAL "-1")
+else()
+    message(WARNING "Only official yosys versions are supported")
+endif()
+
 set(YOSYS_SHARE_DIR ${YOSYS_DATDIR}/plugins/${OUTPUT_NAME})
 
 add_subdirectory(src)

--- a/cmake/FindYosys.cmake
+++ b/cmake/FindYosys.cmake
@@ -79,6 +79,14 @@ else()
         set(YOSYS_DATDIR ${YOSYS_DATDIR})
     endif()
 
+    # Extract version
+    set(YOSYS_DFLAGS ${YOSYS_CXXFLAGS})
+    list(FILTER YOSYS_DFLAGS INCLUDE REGEX "^-DYOSYS_VER=")
+    list(GET YOSYS_DFLAGS 0 YOSYS_VERSION_D)
+    string(REGEX MATCH "\"(.*)\"" YOSYS_VERSION_MATCH ${YOSYS_VERSION_D})
+    set(YOSYS_VERSION ${CMAKE_MATCH_1})
+    message(STATUS "yosys version: ${YOSYS_VERSION}")
+
     add_library(yosys::yosys INTERFACE IMPORTED)
     target_compile_options(yosys::yosys INTERFACE ${YOSYS_CXXFLAGS})
 


### PR DESCRIPTION
Adds a warning to any yosys version with a "+" in it indicating it is not an actual release.