### PR TITLE
Add dsp adder only mapping

### DIFF
--- a/architecture/z1010/dsp/zeroasic_dsp.pmg
+++ b/architecture/z1010/dsp/zeroasic_dsp.pmg
@@ -361,3 +361,286 @@ code argQ
 	dffQ = argQ;
 	dffclock = port(ff, \CLK);
 endcode
+
+
+// ###########################################################################
+// Add-only inference
+//
+// Six of the MAE modes have no multiplier in them at all: 'efpga_adder',
+// 'efpga_adder_regi', 'efpga_adder_rego', 'efpga_adder_regio', 'efpga_acc'
+// and 'efpga_acc_regi'. None of them is reachable from the pattern above,
+// because that one starts from a MAE cell and a MAE cell only ever comes out
+// of the '$mul' driven 'mul2dsp' techmap. A design that adds or accumulates
+// but never multiplies therefore had no path to the MAE and ended up in LUTs.
+//
+// This pattern seeds those modes straight from a '$add', absorbing the same
+// input and output registers as the multiplier flow does, and emits a MAE with
+// 'ADD_ONLY' set so that 'zeroasic_dsp_map_mode.v' remains the single place
+// where a mode gets picked.
+
+pattern zeroasic_dsp_add_pack
+
+state <SigBit> clock
+state <SigSpec> sigA sigB sigP
+state <Cell*> ffA ffB ffP
+state <bool> signedA signedB
+state <bool> useFeedBack
+
+// Variables used for subpatterns
+state <SigSpec> argQ argD
+udata <bool> allowAsync
+udata <SigSpec> dffD dffQ
+udata <SigBit> dffclock
+udata <Cell*> dff
+
+// Narrowest result that is worth a MAE. Set by the 'zeroasic_dsp' pass from
+// its '-add_minwidth' option: without a floor here every carry chain in the
+// design, down to the increment of a small counter, would claim a MAE.
+udata <int> addMinWidth
+
+match add
+	select add->type.in($add)
+	select !add->get_bool_attribute(\keep)
+	select GetSize(port(add, \Y)) <= 40
+endmatch
+
+code sigA sigB sigP signedA signedB ffA ffB ffP clock useFeedBack
+	//helper function to remove unused bits
+	auto unextend = [](const SigSpec &sig) {
+		int i;
+		for (i = GetSize(sig)-1; i > 0; i--)
+			if (sig[i] != sig[i-1])
+				break;
+		// Do not remove non-const sign bit
+		if (sig[i].wire)
+			++i;
+		return sig.extract(0, i);
+	};
+
+	ffA = nullptr;
+	ffB = nullptr;
+	ffP = nullptr;
+	clock = SigBit();
+	useFeedBack = false;
+
+	// Only the bits of 'Y' that somebody reads have to come out of 'P'.
+	SigSpec Y = port(add, \Y);
+	int i;
+	for (i = GetSize(Y)-1; i >= 0; i--)
+		if (nusers(Y[i]) > 1)
+			break;
+	i++;
+	if (i < addMinWidth)
+		reject;
+	sigP = Y.extract(0, i);
+
+	sigA = unextend(port(add, \A));
+	sigB = unextend(port(add, \B));
+	signedA = param(add, \A_SIGNED).as_bool();
+	signedB = param(add, \B_SIGNED).as_bool();
+
+	// A constant operand is an increment or an offset, which stays cheaper in
+	// the fabric than a MAE.
+	if (sigA.is_fully_const() || sigB.is_fully_const())
+		reject;
+endcode
+
+// 'P' output register, and the accumulate feedback it may carry
+code argD ffP sigP clock sigA sigB signedA signedB useFeedBack
+	if (nusers(sigP) == 2) {
+		argD = sigP;
+		allowAsync = false;
+		subpattern(out_add_dffe);
+		if (dff) {
+			ffP = dff;
+			clock = dffclock;
+			// An accumulator is an adder whose registered sum comes back in
+			// as one of its own operands.
+			if (dffQ == sigA) {
+				useFeedBack = true;
+				sigA = sigB;
+				signedA = signedB;
+				sigB = SigSpec();
+			} else if (dffQ == sigB) {
+				useFeedBack = true;
+				sigB = SigSpec();
+			}
+			sigP = dffQ;
+		}
+	}
+endcode
+
+// Check that what is left actually fits one of the six add-only modes.
+code
+	// The MAE is a signed datapath: it sign extends an 18 bit operand into
+	// its 40 bit adder, which is why 'mul2dsp' is handed 'DSP_SIGNEDONLY'.
+	// An unsigned operand therefore needs a spare bit to keep its sign bit
+	// clear, exactly as an unsigned multiply does.
+	auto portWidth = [](const SigSpec &sig, bool is_signed) {
+		return GetSize(sig) + (is_signed ? 0 : 1);
+	};
+
+	if (portWidth(sigA, signedA) > 18)
+		reject;
+
+	// A one bit operand is a sign extended flag, so the '$add' is really an
+	// increment or a decrement. 'mul2dsp' keeps those off the DSP with
+	// 'DSP_A_MINWIDTH' / 'DSP_B_MINWIDTH'; do the same here.
+	if (GetSize(sigA) < 2)
+		reject;
+
+	// An accumulator has no second operand: the other side of the adder is
+	// the 40 bit accumulator, which the macro feeds back internally, and
+	// two's complement addition at that width is the same signed or not.
+	if (!useFeedBack && ((portWidth(sigB, signedB) > 18) ||
+	                     (GetSize(sigB) < 2)))
+		reject;
+endcode
+
+// 'A' input register
+code argQ sigA clock ffA
+	argQ = sigA;
+	allowAsync = false;
+	subpattern(in_add_dffe);
+	if (dff) {
+		ffA = dff;
+		clock = dffclock;
+	}
+endcode
+
+// 'B' input register
+code argQ sigB clock ffB
+	if (!sigB.empty()) {
+		argQ = sigB;
+		allowAsync = false;
+		subpattern(in_add_dffe);
+		if (dff) {
+			ffB = dff;
+			clock = dffclock;
+		}
+	}
+endcode
+
+code
+	accept;
+endcode
+
+// #######################
+// Subpattern for matching against input registers, based on knowledge of the
+//   'Q' input.
+subpattern in_add_dffe
+arg argQ clock
+
+code
+	dff = nullptr;
+	if (argQ.empty())
+		reject;
+	for (const auto &c : argQ.chunks()) {
+		// Abandon matches when 'Q' is a constant
+		if (!c.wire)
+			reject;
+		// Abandon matches when 'Q' has the keep attribute set
+		if (c.wire->get_bool_attribute(\keep))
+			reject;
+		// Abandon matches when 'Q' has a non-zero init attribute set
+		Const init = c.wire->attributes.at(\init, Const());
+		if (!init.empty())
+			for (auto b : init.extract(c.offset, c.width))
+				if (b != State::Sx && b != State::S0)
+					reject;
+	}
+endcode
+
+match ff
+	// all regs must have async reset. can't handle enables.
+	select ff->type.in($dff, $adff, $dffr)
+	// does not support clock inversion
+	select param(ff, \CLK_POLARITY).as_bool()
+
+	// it is possible that only part of a dff output matches argQ
+	slice offset GetSize(port(ff, \D))
+	index <SigBit> port(ff, \Q)[offset] === argQ[0]
+
+	// Check that the rest of argQ is present
+	filter GetSize(port(ff, \Q)) >= offset + GetSize(argQ)
+	filter port(ff, \Q).extract(offset, GetSize(argQ)) == argQ
+
+	// clock must be consistent
+	filter clock == SigBit() || port(ff, \CLK)[0] == clock
+endmatch
+
+code argQ
+	// Check that reset value, if present, is fully 0.
+	bool noResetFlop = ff->type.in($dff, $dffe);
+	bool arstZero = ff->type.in($adff, $adffe) && param(ff, \ARST_VALUE).is_fully_zero();
+	bool resetLegal = noResetFlop || arstZero;
+	if (resetLegal)
+	{
+		SigSpec Q = port(ff, \Q);
+		dff = ff;
+		dffclock = port(ff, \CLK);
+		dffD = argQ;
+		SigSpec D = port(ff, \D);
+		argQ = Q;
+		dffD.replace(argQ, D);
+	}
+endcode
+
+// #######################
+// Subpattern for matching against the output register.
+subpattern out_add_dffe
+arg argD argQ clock
+
+code
+	dff = nullptr;
+	for (auto c : argD.chunks()) {
+		// Abandon matches when 'D' is a constant
+		if (!c.wire)
+			reject;
+		// Abandon matches when 'D' has the keep attribute set
+		if (c.wire->get_bool_attribute(\keep))
+			reject;
+	}
+endcode
+
+match ff
+	select ff->type.in($dff, $adff, $dffr)
+	// does not support clock inversion
+	select param(ff, \CLK_POLARITY).as_bool()
+
+	slice offset GetSize(port(ff, \D))
+	index <SigBit> port(ff, \D)[offset] === argD[0]
+
+	// Check that the rest of argD is present
+	filter GetSize(port(ff, \D)) >= offset + GetSize(argD)
+	filter port(ff, \D).extract(offset, GetSize(argD)) == argD
+
+	filter clock == SigBit() || port(ff, \CLK)[0] == clock
+endmatch
+
+code argQ
+	// The macro always clears its output register, so a flop that resets to
+	// anything else cannot be packed into it.
+	if (ff->type.in($adff, $adffe) && !param(ff, \ARST_VALUE).is_fully_zero())
+		reject;
+
+	{
+		SigSpec D = port(ff, \D);
+		SigSpec Q = port(ff, \Q);
+		argQ = argD;
+		argQ.replace(D, Q);
+	}
+
+	// Abandon matches when 'Q' has a non-zero init attribute set
+	for (auto c : argQ.chunks()) {
+		Const init = c.wire->attributes.at(\init, Const());
+		if (!init.empty())
+			for (auto b : init.extract(c.offset, c.width))
+				if (b != State::Sx && b != State::S0)
+					reject;
+	}
+
+	dff = ff;
+	dffQ = argQ;
+	dffclock = port(ff, \CLK);
+endcode

--- a/architecture/z1010/dsp/zeroasic_dsp_map_mode.v
+++ b/architecture/z1010/dsp/zeroasic_dsp_map_mode.v
@@ -5,7 +5,10 @@ module MAE #(
   parameter P_REG=0,
   parameter MULT_HAS_REG=0,
   parameter POST_ADDER_STATIC=0,
-  parameter USE_FEEDBACK=0
+  parameter USE_FEEDBACK=0,
+  // Multiplier bypassed: 'A' and 'B' (or 'A' and the accumulator) go straight
+  // into the adder. Set by 'zeroasic_dsp' when it seeds a MAE from a '$add'.
+  parameter ADD_ONLY=0
  )
 (
   input [17:0] A,
@@ -30,7 +33,63 @@ module MAE #(
 );
 
 generate
-  if (A_REG == 1'b1 && B_REG == 1'b1 && P_REG==1'b0 && POST_ADDER_STATIC==1'b0) begin
+  if (ADD_ONLY == 1'b1 && USE_FEEDBACK == 1'b0 && A_REG == 1'b0 && B_REG == 1'b0 && P_REG == 1'b0) begin
+    efpga_adder _TECHMAP_REPLACE_ (
+      .a(A),
+      .b(B),
+      .y(P)
+    );
+  end
+  else if (ADD_ONLY == 1'b1 && USE_FEEDBACK == 1'b0 && A_REG == 1'b1 && B_REG == 1'b1 && P_REG == 1'b0) begin
+    efpga_adder_regi _TECHMAP_REPLACE_ (
+      .a(A),
+      .b(B),
+      .clk(CLK),
+      .resetn(resetn),
+      .y(P)
+    );
+  end
+  else if (ADD_ONLY == 1'b1 && USE_FEEDBACK == 1'b0 && A_REG == 1'b0 && B_REG == 1'b0 && P_REG == 1'b1) begin
+    efpga_adder_rego _TECHMAP_REPLACE_ (
+      .a(A),
+      .b(B),
+      .clk(CLK),
+      .resetn(resetn),
+      .y(P)
+    );
+  end
+  else if (ADD_ONLY == 1'b1 && USE_FEEDBACK == 1'b0 && A_REG == 1'b1 && B_REG == 1'b1 && P_REG == 1'b1) begin
+    efpga_adder_regio _TECHMAP_REPLACE_ (
+      .a(A),
+      .b(B),
+      .clk(CLK),
+      .resetn(resetn),
+      .y(P)
+    );
+  end
+  else if (ADD_ONLY == 1'b1 && USE_FEEDBACK == 1'b1 && A_REG == 1'b0 && P_REG == 1'b1) begin
+    efpga_acc _TECHMAP_REPLACE_ (
+      .a(A),
+      .clk(CLK),
+      .resetn(resetn),
+      .y(P)
+    );
+  end
+  else if (ADD_ONLY == 1'b1 && USE_FEEDBACK == 1'b1 && A_REG == 1'b1 && P_REG == 1'b1) begin
+    efpga_acc_regi _TECHMAP_REPLACE_ (
+      .a(A),
+      .clk(CLK),
+      .resetn(resetn),
+      .y(P)
+    );
+  end
+  // Every add-only combination 'zeroasic_dsp' can produce is listed above, so
+  // anything else with the multiplier bypassed is a bug. Fail loudly rather
+  // than fall through into a multiplier mode below.
+  else if (ADD_ONLY == 1'b1) begin
+    wire _TECHMAP_FAIL_ = 1'b1;
+  end
+  else if (A_REG == 1'b1 && B_REG == 1'b1 && P_REG==1'b0 && POST_ADDER_STATIC==1'b0) begin
     efpga_mult_regi _TECHMAP_REPLACE_ (
       .a(A),
       .b(B),

--- a/architecture/z1060/dsp/zeroasic_dsp.pmg
+++ b/architecture/z1060/dsp/zeroasic_dsp.pmg
@@ -361,3 +361,286 @@ code argQ
 	dffQ = argQ;
 	dffclock = port(ff, \CLK);
 endcode
+
+
+// ###########################################################################
+// Add-only inference
+//
+// Six of the MAE modes have no multiplier in them at all: 'efpga_adder',
+// 'efpga_adder_regi', 'efpga_adder_rego', 'efpga_adder_regio', 'efpga_acc'
+// and 'efpga_acc_regi'. None of them is reachable from the pattern above,
+// because that one starts from a MAE cell and a MAE cell only ever comes out
+// of the '$mul' driven 'mul2dsp' techmap. A design that adds or accumulates
+// but never multiplies therefore had no path to the MAE and ended up in LUTs.
+//
+// This pattern seeds those modes straight from a '$add', absorbing the same
+// input and output registers as the multiplier flow does, and emits a MAE with
+// 'ADD_ONLY' set so that 'zeroasic_dsp_map_mode.v' remains the single place
+// where a mode gets picked.
+
+pattern zeroasic_dsp_add_pack
+
+state <SigBit> clock
+state <SigSpec> sigA sigB sigP
+state <Cell*> ffA ffB ffP
+state <bool> signedA signedB
+state <bool> useFeedBack
+
+// Variables used for subpatterns
+state <SigSpec> argQ argD
+udata <bool> allowAsync
+udata <SigSpec> dffD dffQ
+udata <SigBit> dffclock
+udata <Cell*> dff
+
+// Narrowest result that is worth a MAE. Set by the 'zeroasic_dsp' pass from
+// its '-add_minwidth' option: without a floor here every carry chain in the
+// design, down to the increment of a small counter, would claim a MAE.
+udata <int> addMinWidth
+
+match add
+	select add->type.in($add)
+	select !add->get_bool_attribute(\keep)
+	select GetSize(port(add, \Y)) <= 40
+endmatch
+
+code sigA sigB sigP signedA signedB ffA ffB ffP clock useFeedBack
+	//helper function to remove unused bits
+	auto unextend = [](const SigSpec &sig) {
+		int i;
+		for (i = GetSize(sig)-1; i > 0; i--)
+			if (sig[i] != sig[i-1])
+				break;
+		// Do not remove non-const sign bit
+		if (sig[i].wire)
+			++i;
+		return sig.extract(0, i);
+	};
+
+	ffA = nullptr;
+	ffB = nullptr;
+	ffP = nullptr;
+	clock = SigBit();
+	useFeedBack = false;
+
+	// Only the bits of 'Y' that somebody reads have to come out of 'P'.
+	SigSpec Y = port(add, \Y);
+	int i;
+	for (i = GetSize(Y)-1; i >= 0; i--)
+		if (nusers(Y[i]) > 1)
+			break;
+	i++;
+	if (i < addMinWidth)
+		reject;
+	sigP = Y.extract(0, i);
+
+	sigA = unextend(port(add, \A));
+	sigB = unextend(port(add, \B));
+	signedA = param(add, \A_SIGNED).as_bool();
+	signedB = param(add, \B_SIGNED).as_bool();
+
+	// A constant operand is an increment or an offset, which stays cheaper in
+	// the fabric than a MAE.
+	if (sigA.is_fully_const() || sigB.is_fully_const())
+		reject;
+endcode
+
+// 'P' output register, and the accumulate feedback it may carry
+code argD ffP sigP clock sigA sigB signedA signedB useFeedBack
+	if (nusers(sigP) == 2) {
+		argD = sigP;
+		allowAsync = false;
+		subpattern(out_add_dffe);
+		if (dff) {
+			ffP = dff;
+			clock = dffclock;
+			// An accumulator is an adder whose registered sum comes back in
+			// as one of its own operands.
+			if (dffQ == sigA) {
+				useFeedBack = true;
+				sigA = sigB;
+				signedA = signedB;
+				sigB = SigSpec();
+			} else if (dffQ == sigB) {
+				useFeedBack = true;
+				sigB = SigSpec();
+			}
+			sigP = dffQ;
+		}
+	}
+endcode
+
+// Check that what is left actually fits one of the six add-only modes.
+code
+	// The MAE is a signed datapath: it sign extends an 18 bit operand into
+	// its 40 bit adder, which is why 'mul2dsp' is handed 'DSP_SIGNEDONLY'.
+	// An unsigned operand therefore needs a spare bit to keep its sign bit
+	// clear, exactly as an unsigned multiply does.
+	auto portWidth = [](const SigSpec &sig, bool is_signed) {
+		return GetSize(sig) + (is_signed ? 0 : 1);
+	};
+
+	if (portWidth(sigA, signedA) > 18)
+		reject;
+
+	// A one bit operand is a sign extended flag, so the '$add' is really an
+	// increment or a decrement. 'mul2dsp' keeps those off the DSP with
+	// 'DSP_A_MINWIDTH' / 'DSP_B_MINWIDTH'; do the same here.
+	if (GetSize(sigA) < 2)
+		reject;
+
+	// An accumulator has no second operand: the other side of the adder is
+	// the 40 bit accumulator, which the macro feeds back internally, and
+	// two's complement addition at that width is the same signed or not.
+	if (!useFeedBack && ((portWidth(sigB, signedB) > 18) ||
+	                     (GetSize(sigB) < 2)))
+		reject;
+endcode
+
+// 'A' input register
+code argQ sigA clock ffA
+	argQ = sigA;
+	allowAsync = false;
+	subpattern(in_add_dffe);
+	if (dff) {
+		ffA = dff;
+		clock = dffclock;
+	}
+endcode
+
+// 'B' input register
+code argQ sigB clock ffB
+	if (!sigB.empty()) {
+		argQ = sigB;
+		allowAsync = false;
+		subpattern(in_add_dffe);
+		if (dff) {
+			ffB = dff;
+			clock = dffclock;
+		}
+	}
+endcode
+
+code
+	accept;
+endcode
+
+// #######################
+// Subpattern for matching against input registers, based on knowledge of the
+//   'Q' input.
+subpattern in_add_dffe
+arg argQ clock
+
+code
+	dff = nullptr;
+	if (argQ.empty())
+		reject;
+	for (const auto &c : argQ.chunks()) {
+		// Abandon matches when 'Q' is a constant
+		if (!c.wire)
+			reject;
+		// Abandon matches when 'Q' has the keep attribute set
+		if (c.wire->get_bool_attribute(\keep))
+			reject;
+		// Abandon matches when 'Q' has a non-zero init attribute set
+		Const init = c.wire->attributes.at(\init, Const());
+		if (!init.empty())
+			for (auto b : init.extract(c.offset, c.width))
+				if (b != State::Sx && b != State::S0)
+					reject;
+	}
+endcode
+
+match ff
+	// all regs must have async reset. can't handle enables.
+	select ff->type.in($dff, $adff, $dffr)
+	// does not support clock inversion
+	select param(ff, \CLK_POLARITY).as_bool()
+
+	// it is possible that only part of a dff output matches argQ
+	slice offset GetSize(port(ff, \D))
+	index <SigBit> port(ff, \Q)[offset] === argQ[0]
+
+	// Check that the rest of argQ is present
+	filter GetSize(port(ff, \Q)) >= offset + GetSize(argQ)
+	filter port(ff, \Q).extract(offset, GetSize(argQ)) == argQ
+
+	// clock must be consistent
+	filter clock == SigBit() || port(ff, \CLK)[0] == clock
+endmatch
+
+code argQ
+	// Check that reset value, if present, is fully 0.
+	bool noResetFlop = ff->type.in($dff, $dffe);
+	bool arstZero = ff->type.in($adff, $adffe) && param(ff, \ARST_VALUE).is_fully_zero();
+	bool resetLegal = noResetFlop || arstZero;
+	if (resetLegal)
+	{
+		SigSpec Q = port(ff, \Q);
+		dff = ff;
+		dffclock = port(ff, \CLK);
+		dffD = argQ;
+		SigSpec D = port(ff, \D);
+		argQ = Q;
+		dffD.replace(argQ, D);
+	}
+endcode
+
+// #######################
+// Subpattern for matching against the output register.
+subpattern out_add_dffe
+arg argD argQ clock
+
+code
+	dff = nullptr;
+	for (auto c : argD.chunks()) {
+		// Abandon matches when 'D' is a constant
+		if (!c.wire)
+			reject;
+		// Abandon matches when 'D' has the keep attribute set
+		if (c.wire->get_bool_attribute(\keep))
+			reject;
+	}
+endcode
+
+match ff
+	select ff->type.in($dff, $adff, $dffr)
+	// does not support clock inversion
+	select param(ff, \CLK_POLARITY).as_bool()
+
+	slice offset GetSize(port(ff, \D))
+	index <SigBit> port(ff, \D)[offset] === argD[0]
+
+	// Check that the rest of argD is present
+	filter GetSize(port(ff, \D)) >= offset + GetSize(argD)
+	filter port(ff, \D).extract(offset, GetSize(argD)) == argD
+
+	filter clock == SigBit() || port(ff, \CLK)[0] == clock
+endmatch
+
+code argQ
+	// The macro always clears its output register, so a flop that resets to
+	// anything else cannot be packed into it.
+	if (ff->type.in($adff, $adffe) && !param(ff, \ARST_VALUE).is_fully_zero())
+		reject;
+
+	{
+		SigSpec D = port(ff, \D);
+		SigSpec Q = port(ff, \Q);
+		argQ = argD;
+		argQ.replace(D, Q);
+	}
+
+	// Abandon matches when 'Q' has a non-zero init attribute set
+	for (auto c : argQ.chunks()) {
+		Const init = c.wire->attributes.at(\init, Const());
+		if (!init.empty())
+			for (auto b : init.extract(c.offset, c.width))
+				if (b != State::Sx && b != State::S0)
+					reject;
+	}
+
+	dff = ff;
+	dffQ = argQ;
+	dffclock = port(ff, \CLK);
+endcode

--- a/architecture/z1060/dsp/zeroasic_dsp_map_mode.v
+++ b/architecture/z1060/dsp/zeroasic_dsp_map_mode.v
@@ -5,7 +5,10 @@ module MAE #(
   parameter P_REG=0,
   parameter MULT_HAS_REG=0,
   parameter POST_ADDER_STATIC=0,
-  parameter USE_FEEDBACK=0
+  parameter USE_FEEDBACK=0,
+  // Multiplier bypassed: 'A' and 'B' (or 'A' and the accumulator) go straight
+  // into the adder. Set by 'zeroasic_dsp' when it seeds a MAE from a '$add'.
+  parameter ADD_ONLY=0
  )
 (
   input [17:0] A,
@@ -30,7 +33,63 @@ module MAE #(
 );
 
 generate
-  if (A_REG == 1'b1 && B_REG == 1'b1 && P_REG==1'b0 && POST_ADDER_STATIC==1'b0) begin
+  if (ADD_ONLY == 1'b1 && USE_FEEDBACK == 1'b0 && A_REG == 1'b0 && B_REG == 1'b0 && P_REG == 1'b0) begin
+    efpga_adder _TECHMAP_REPLACE_ (
+      .a(A),
+      .b(B),
+      .y(P)
+    );
+  end
+  else if (ADD_ONLY == 1'b1 && USE_FEEDBACK == 1'b0 && A_REG == 1'b1 && B_REG == 1'b1 && P_REG == 1'b0) begin
+    efpga_adder_regi _TECHMAP_REPLACE_ (
+      .a(A),
+      .b(B),
+      .clk(CLK),
+      .resetn(resetn),
+      .y(P)
+    );
+  end
+  else if (ADD_ONLY == 1'b1 && USE_FEEDBACK == 1'b0 && A_REG == 1'b0 && B_REG == 1'b0 && P_REG == 1'b1) begin
+    efpga_adder_rego _TECHMAP_REPLACE_ (
+      .a(A),
+      .b(B),
+      .clk(CLK),
+      .resetn(resetn),
+      .y(P)
+    );
+  end
+  else if (ADD_ONLY == 1'b1 && USE_FEEDBACK == 1'b0 && A_REG == 1'b1 && B_REG == 1'b1 && P_REG == 1'b1) begin
+    efpga_adder_regio _TECHMAP_REPLACE_ (
+      .a(A),
+      .b(B),
+      .clk(CLK),
+      .resetn(resetn),
+      .y(P)
+    );
+  end
+  else if (ADD_ONLY == 1'b1 && USE_FEEDBACK == 1'b1 && A_REG == 1'b0 && P_REG == 1'b1) begin
+    efpga_acc _TECHMAP_REPLACE_ (
+      .a(A),
+      .clk(CLK),
+      .resetn(resetn),
+      .y(P)
+    );
+  end
+  else if (ADD_ONLY == 1'b1 && USE_FEEDBACK == 1'b1 && A_REG == 1'b1 && P_REG == 1'b1) begin
+    efpga_acc_regi _TECHMAP_REPLACE_ (
+      .a(A),
+      .clk(CLK),
+      .resetn(resetn),
+      .y(P)
+    );
+  end
+  // Every add-only combination 'zeroasic_dsp' can produce is listed above, so
+  // anything else with the multiplier bypassed is a bug. Fail loudly rather
+  // than fall through into a multiplier mode below.
+  else if (ADD_ONLY == 1'b1) begin
+    wire _TECHMAP_FAIL_ = 1'b1;
+  end
+  else if (A_REG == 1'b1 && B_REG == 1'b1 && P_REG==1'b0 && POST_ADDER_STATIC==1'b0) begin
     efpga_mult_regi _TECHMAP_REPLACE_ (
       .a(A),
       .b(B),

--- a/src/synth_fpga.cc
+++ b/src/synth_fpga.cc
@@ -53,6 +53,7 @@ struct SynthFpgaPass : public ScriptPass {
   bool no_xor_tree_process;
   bool no_opt_const_dff;
   bool no_dsp_pack;
+  bool no_dsp_add;
   bool show_dff_init_value;
   bool continue_if_latch;
   bool set_dff_init_value_to_zero;
@@ -2873,6 +2874,12 @@ struct SynthFpgaPass : public ScriptPass {
     // Call the DSP packer command
     //
     if ((sc_syn_dsps_pack_command != "") && (!no_dsp_pack)) {
+      // '-no_add' is a 'zeroasic_dsp' option; the pack command is
+      // configurable, so do not hand it to anything else.
+      if (no_dsp_add &&
+          (sc_syn_dsps_pack_command.rfind("zeroasic_dsp", 0) == 0)) {
+        sc_syn_dsps_pack_command += " -no_add";
+      }
       run(sc_syn_dsps_pack_command);
     }
 
@@ -3066,6 +3073,12 @@ struct SynthFpgaPass : public ScriptPass {
     log("        Disable DSP packing.\n");
     log("\n");
 
+    log("    -no_dsp_add\n");
+    log("        Disable inference of the add-only DSP modes, leaving adders "
+        "and\n");
+    log("        accumulators in the fabric.\n");
+    log("\n");
+
     log("    -fsm_encoding [one-hot, binary]\n");
     log("        Specifies FSM encoding : by default a 'one-hot' encoding is "
         "performed.\n");
@@ -3214,6 +3227,7 @@ struct SynthFpgaPass : public ScriptPass {
     no_xor_tree_process = false;
     no_opt_const_dff = false;
     no_dsp_pack = false;
+    no_dsp_add = false;
     show_dff_init_value = false;
     set_dff_init_value_to_zero = false;
     continue_if_latch = false;
@@ -3337,6 +3351,11 @@ struct SynthFpgaPass : public ScriptPass {
 
       if (args[argidx] == "-no_dsp_pack") {
         no_dsp_pack = true;
+        continue;
+      }
+
+      if (args[argidx] == "-no_dsp_add") {
+        no_dsp_add = true;
         continue;
       }
 

--- a/src/zeroasic_dsp.cc
+++ b/src/zeroasic_dsp.cc
@@ -25,6 +25,10 @@ PRIVATE_NAMESPACE_BEGIN
 
 #include "zeroasic_dsp.h"
 
+// An 18 bit add costs about as many LUTs as it has result bits, so anything
+// narrower than this is not worth a DSP that a multiplier could have used.
+static const int DEFAULT_ADD_MINWIDTH = 10;
+
 void zeroasic_dsp_pack(zeroasic_dsp_pm &pm) {
   auto &st = pm.st_zeroasic_dsp_pack;
 
@@ -178,6 +182,150 @@ void zeroasic_dsp_pack(zeroasic_dsp_pm &pm) {
   pm.blacklist(cell);
 }
 
+// The six add-only MAE modes ('efpga_adder', 'efpga_adder_regi',
+// 'efpga_adder_rego', 'efpga_adder_regio', 'efpga_acc' and 'efpga_acc_regi')
+// have no multiplier in them, so the '$mul' driven 'mul2dsp' techmap never
+// produces a MAE for a design that only adds or accumulates. Seed one here
+// from the '$add' that 'zeroasic_dsp_add_pack' matched, with 'ADD_ONLY' set so
+// that 'zeroasic_dsp_map_mode.v' stays the single place where a mode is picked.
+//
+void zeroasic_dsp_add_pack(zeroasic_dsp_pm &pm) {
+  auto &st = pm.st_zeroasic_dsp_add_pack;
+
+  Module *module = pm.module;
+  Cell *add = st.add;
+
+  Cell *ffA = st.ffA;
+  Cell *ffB = st.ffB;
+  Cell *ffP = st.ffP;
+
+  // 'efpga_adder_regi' and 'efpga_adder_regio' register both operands out of
+  // the same flops, so a single registered operand is not a mode we have.
+  if (!st.useFeedBack && !(ffA && ffB)) {
+    ffA = nullptr;
+    ffB = nullptr;
+  }
+
+  // The macro has one active low asynchronous reset shared by every register
+  // it holds, so only pack flops that agree on it. '$dff' (no reset at all)
+  // does not agree with a flop that has one.
+  auto arst = [](Cell *ff) {
+    if (ff && ff->type.in(ID($adff), ID($adffe)))
+      return ff->getPort(ID::ARST);
+    return SigSpec();
+  };
+  auto arstPolarity = [](Cell *ff) {
+    if (ff && ff->type.in(ID($adff), ID($adffe)))
+      return ff->getParam(ID::ARST_POLARITY).as_bool();
+    return false;
+  };
+  auto sameReset = [&](Cell *a, Cell *b) {
+    return arst(a) == arst(b) && arstPolarity(a) == arstPolarity(b);
+  };
+
+  if (ffP && ffA && !sameReset(ffP, ffA)) {
+    ffA = nullptr;
+    ffB = nullptr;
+  }
+  if (ffA && ffB && !sameReset(ffA, ffB)) {
+    ffA = nullptr;
+    ffB = nullptr;
+  }
+
+  // Move an operand past the register that feeds it, and extend it to the
+  // 18 bits of the macro input port.
+  auto operand = [&](SigSpec sig, Cell *ff, bool is_signed) {
+    if (ff) {
+      SigSpec D = ff->getPort(ID::D);
+      SigSpec Q = pm.sigmap(ff->getPort(ID::Q));
+      sig.replace(Q, D);
+    }
+    SigBit pad = is_signed ? sig[GetSize(sig) - 1] : SigBit(State::S0);
+    while (GetSize(sig) < 18)
+      sig.append(pad);
+    return sig;
+  };
+
+  Cell *cell = module->addCell(NEW_ID, ID(MAE));
+
+  cell->setParam(ID(ADD_ONLY), State::S1);
+  cell->setParam(ID(POST_ADDER_STATIC), State::S0);
+  cell->setParam(ID(MULT_HAS_REG), State::S0);
+  cell->setParam(ID(C_REG), State::S0);
+  cell->setParam(ID(USE_FEEDBACK), st.useFeedBack ? State::S1 : State::S0);
+  cell->setParam(ID(A_REG), ffA ? State::S1 : State::S0);
+  cell->setParam(ID(B_REG), ffB ? State::S1 : State::S0);
+  cell->setParam(ID(P_REG), ffP ? State::S1 : State::S0);
+
+  SigSpec A = operand(st.sigA, ffA, st.signedA);
+  cell->setPort(ID::A, A);
+  pm.add_siguser(A, cell);
+
+  // An accumulator has no second operand: the other side of its adder is the
+  // accumulator itself, which the macro feeds back internally.
+  SigSpec B = st.useFeedBack ? SigSpec(State::S0, 18)
+                             : operand(st.sigB, ffB, st.signedB);
+  cell->setPort(ID::B, B);
+  pm.add_siguser(B, cell);
+
+  cell->setPort(ID::C, SigSpec(State::S0, 40));
+
+  SigSpec P = st.sigP;
+  if (GetSize(P) < 40)
+    P.append(module->addWire(NEW_ID, 40 - GetSize(P)));
+  cell->setPort(ID::P, P);
+
+  if (st.clock != SigBit()) {
+    cell->setPort(ID::CLK, st.clock);
+
+    Cell *rstFrom = ffP ? ffP : ffA;
+    SigSpec resetn = arst(rstFrom);
+    if (resetn.empty())
+      resetn = State::S1;
+    else if (arstPolarity(rstFrom))
+      resetn = module->Not(NEW_ID, resetn);
+    cell->setPort(ID(resetn), resetn);
+
+    log("  clock: %s (%s)\n", log_signal(st.clock), "posedge");
+    if (ffA)
+      log(" \t ffA:%s\n", log_id(ffA));
+    if (ffB)
+      log(" \t ffB:%s\n", log_id(ffB));
+    if (ffP)
+      log(" \t ffP:%s\n", log_id(ffP));
+  }
+
+  // Hand the output register's own net over to 'P' and leave the flop
+  // dangling for 'opt_clean', the way the multiplier path does.
+  if (ffP) {
+    ffP->connections_.at(ID::Q).replace(
+        st.sigP, module->addWire(NEW_ID, GetSize(st.sigP)));
+
+    SigSpec Q = pm.sigmap(st.sigP);
+    for (auto c : Q.chunks()) {
+      if (c.wire == nullptr)
+        continue;
+      auto it = c.wire->attributes.find(ID::init);
+      if (it == c.wire->attributes.end())
+        continue;
+      for (int i = c.offset; i < c.offset + c.width; i++) {
+        if (i >= GetSize(it->second))
+          break;
+#if YOSYS_MAJOR == 0 && YOSYS_MINOR <= 57
+        it->second.bits()[i] = State::Sx;
+#else
+        it->second.set(i, State::Sx);
+#endif
+      }
+    }
+  }
+
+  log("\n");
+
+  pm.autoremove(add);
+  pm.blacklist(cell);
+}
+
 struct ZeroAsicDspPass : public Pass {
   ZeroAsicDspPass()
       : Pass("zeroasic_dsp", "ZEROASIC: pack resources into DSPs") {}
@@ -192,13 +340,43 @@ struct ZeroAsicDspPass : public Pass {
         "post-adder into\n");
     log("ZeroAsic DSP resources.\n");
     log("\n");
+    log("A second pass then infers the add-only DSP modes ('efpga_adder*' "
+        "and\n");
+    log("'efpga_acc*') from any '$add' left over, which the '$mul' driven "
+        "techmap\n");
+    log("cannot reach.\n");
+    log("\n");
+    log("    -no_add\n");
+    log("        do not infer the add-only modes, leaving every remaining "
+        "'$add' to\n");
+    log("        the fabric.\n");
+    log("\n");
+    log("    -add_minwidth <n>\n");
+    log("        smallest add result width worth a DSP (default %d). Below "
+        "this an\n",
+        DEFAULT_ADD_MINWIDTH);
+    log("        '$add' stays in the fabric so that narrow carry chains do "
+        "not use up\n");
+    log("        the DSPs.\n");
+    log("\n");
   }
 
   void execute(std::vector<std::string> args, RTLIL::Design *design) override {
     log_header(design, "Executing ZEROASIC_DSP pass (pack DFFs into DSPs).\n");
 
+    bool no_add = false;
+    int add_minwidth = DEFAULT_ADD_MINWIDTH;
+
     size_t argidx;
     for (argidx = 1; argidx < args.size(); argidx++) {
+      if (args[argidx] == "-no_add") {
+        no_add = true;
+        continue;
+      }
+      if ((args[argidx] == "-add_minwidth") && (argidx + 1 < args.size())) {
+        add_minwidth = max(2, atoi(args[++argidx].c_str()));
+        continue;
+      }
       break;
     }
     extra_args(args, argidx, design);
@@ -211,6 +389,15 @@ struct ZeroAsicDspPass : public Pass {
       {
         zeroasic_dsp_pm pm(module, module->selected_cells());
         pm.run_zeroasic_dsp_pack(zeroasic_dsp_pack);
+      }
+
+      // Runs on a fresh matcher so that the '$add' cells the multiplier pass
+      // absorbed above are gone before the add-only modes get a look at what
+      // is left.
+      if (!no_add) {
+        zeroasic_dsp_pm pm(module, module->selected_cells());
+        pm.ud_zeroasic_dsp_add_pack.addMinWidth = add_minwidth;
+        pm.run_zeroasic_dsp_add_pack(zeroasic_dsp_add_pack);
       }
     }
   }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,12 @@ set(ALL_TESTS
     unit/dsp/mae-techmap-efpga_mult_addc_regi.ys
     unit/dsp/mae-techmap-efpga_mult_addc_rego.ys
     unit/dsp/mae-techmap-efpga_mult_addc_regio.ys
+    unit/dsp/mae-techmap-efpga_adder.ys
+    unit/dsp/mae-techmap-efpga_adder_regi.ys
+    unit/dsp/mae-techmap-efpga_adder_rego.ys
+    unit/dsp/mae-techmap-efpga_adder_regio.ys
+    unit/dsp/mae-techmap-efpga_acc.ys
+    unit/dsp/mae-techmap-efpga_acc_regi.ys
     unit/dsp/mae-techmap-efpga_mult_unsigned.ys
     unit/dsp/mae-techmap-efpga_mult_regi_unsigned.ys
     unit/dsp/mae-techmap-efpga_mult_rego_unsigned.ys
@@ -31,6 +37,14 @@ set(ALL_TESTS
     unit/dsp/mae-techmap-efpga_mult_addc_regi_unsigned.ys
     unit/dsp/mae-techmap-efpga_mult_addc_rego_unsigned.ys
     unit/dsp/mae-techmap-efpga_mult_addc_regio_unsigned.ys
+    unit/dsp/mae-techmap-efpga_adder_unsigned.ys
+    unit/dsp/mae-techmap-efpga_adder_regi_unsigned.ys
+    unit/dsp/mae-techmap-efpga_adder_rego_unsigned.ys
+    unit/dsp/mae-techmap-efpga_adder_regio_unsigned.ys
+    unit/dsp/mae-techmap-efpga_acc_unsigned.ys
+    unit/dsp/mae-techmap-efpga_acc_regi_unsigned.ys
+    unit/dsp/mae-techmap-efpga_add_nomap.ys
+    unit/dsp/mae-techmap-efpga_add_partial_pack.ys
 )
 
 foreach(test_script ${ALL_TESTS})

--- a/tests/unit/dsp/mae-techmap-efpga_acc.ys
+++ b/tests/unit/dsp/mae-techmap-efpga_acc.ys
@@ -1,0 +1,30 @@
+# yosys -m wildebeest -s mae-techmap-efpga_acc.ys
+read_verilog <<EOF
+module efpga_acc_map_inst
+  # (
+     parameter INPUT_WIDTH = 18,
+     parameter OUTPUT_WIDTH = 40
+     )
+   (
+    input                                   clk,
+    input                                   resetn,
+    input signed [(INPUT_WIDTH-1):0]          a,
+    output reg signed [(OUTPUT_WIDTH-1):0]    y
+    );
+
+   always @(posedge clk or negedge resetn) begin
+      if (~resetn) begin
+         y <= 'h0;
+      end
+      else begin
+         y <= y + a;
+      end
+   end
+
+endmodule
+EOF
+
+synth_fpga -partname z1010
+select -assert-count 1 */t:efpga_acc
+select -assert-count 1 */t:efpga_acc %x:+[clk] */w:clk %i
+select -assert-count 1 */t:efpga_acc %x:+[resetn] */w:resetn %i

--- a/tests/unit/dsp/mae-techmap-efpga_acc_regi.ys
+++ b/tests/unit/dsp/mae-techmap-efpga_acc_regi.ys
@@ -1,0 +1,41 @@
+# yosys -m wildebeest -s mae-techmap-efpga_acc_regi.ys
+read_verilog <<EOF
+module efpga_acc_regi_map_inst
+  # (
+     parameter INPUT_WIDTH = 18,
+     parameter OUTPUT_WIDTH = 40
+     )
+   (
+    input                                   clk,
+    input                                   resetn,
+    input signed [(INPUT_WIDTH-1):0]          a,
+    output reg signed [(OUTPUT_WIDTH-1):0]    y
+    );
+
+   reg signed [(INPUT_WIDTH-1):0] a_reg;
+
+   always @(posedge clk or negedge resetn) begin
+      if (~resetn) begin
+         a_reg <= 'h0;
+      end
+      else begin
+         a_reg <= a;
+      end
+   end
+
+   always @(posedge clk or negedge resetn) begin
+      if (~resetn) begin
+         y <= 'h0;
+      end
+      else begin
+         y <= y + a_reg;
+      end
+   end
+
+endmodule
+EOF
+
+synth_fpga -partname z1010
+select -assert-count 1 */t:efpga_acc_regi
+select -assert-count 1 */t:efpga_acc_regi %x:+[clk] */w:clk %i
+select -assert-count 1 */t:efpga_acc_regi %x:+[resetn] */w:resetn %i

--- a/tests/unit/dsp/mae-techmap-efpga_acc_regi_unsigned.ys
+++ b/tests/unit/dsp/mae-techmap-efpga_acc_regi_unsigned.ys
@@ -1,0 +1,41 @@
+# yosys -m wildebeest -s mae-techmap-efpga_acc_regi_unsigned.ys
+read_verilog <<EOF
+module efpga_acc_regi_unsigned_map_inst
+  # (
+     parameter INPUT_WIDTH = 17,
+     parameter OUTPUT_WIDTH = 40
+     )
+   (
+    input                                   clk,
+    input                                   resetn,
+    input [(INPUT_WIDTH-1):0]          a,
+    output reg [(OUTPUT_WIDTH-1):0]    y
+    );
+
+   reg [(INPUT_WIDTH-1):0] a_reg;
+
+   always @(posedge clk or negedge resetn) begin
+      if (~resetn) begin
+         a_reg <= 'h0;
+      end
+      else begin
+         a_reg <= a;
+      end
+   end
+
+   always @(posedge clk or negedge resetn) begin
+      if (~resetn) begin
+         y <= 'h0;
+      end
+      else begin
+         y <= y + a_reg;
+      end
+   end
+
+endmodule
+EOF
+
+synth_fpga -partname z1010
+select -assert-count 1 */t:efpga_acc_regi
+select -assert-count 1 */t:efpga_acc_regi %x:+[clk] */w:clk %i
+select -assert-count 1 */t:efpga_acc_regi %x:+[resetn] */w:resetn %i

--- a/tests/unit/dsp/mae-techmap-efpga_acc_unsigned.ys
+++ b/tests/unit/dsp/mae-techmap-efpga_acc_unsigned.ys
@@ -1,0 +1,30 @@
+# yosys -m wildebeest -s mae-techmap-efpga_acc_unsigned.ys
+read_verilog <<EOF
+module efpga_acc_unsigned_map_inst
+  # (
+     parameter INPUT_WIDTH = 17,
+     parameter OUTPUT_WIDTH = 40
+     )
+   (
+    input                                   clk,
+    input                                   resetn,
+    input [(INPUT_WIDTH-1):0]          a,
+    output reg [(OUTPUT_WIDTH-1):0]    y
+    );
+
+   always @(posedge clk or negedge resetn) begin
+      if (~resetn) begin
+         y <= 'h0;
+      end
+      else begin
+         y <= y + a;
+      end
+   end
+
+endmodule
+EOF
+
+synth_fpga -partname z1010
+select -assert-count 1 */t:efpga_acc
+select -assert-count 1 */t:efpga_acc %x:+[clk] */w:clk %i
+select -assert-count 1 */t:efpga_acc %x:+[resetn] */w:resetn %i

--- a/tests/unit/dsp/mae-techmap-efpga_add_nomap.ys
+++ b/tests/unit/dsp/mae-techmap-efpga_add_nomap.ys
@@ -1,0 +1,46 @@
+# yosys -m wildebeest -s mae-techmap-efpga_add_nomap.ys
+#
+# The add-only MAE modes are inferred from a plain '$add', so the guards that
+# keep an ordinary carry chain out of the DSPs are worth pinning down. None of
+# the four adds below should reach a MAE.
+read_verilog <<EOF
+module efpga_add_nomap_map_inst
+   (
+    input                                   clk,
+    input                                   resetn,
+    // wider than the 18 bit MAE operand ports
+    input [31:0]                            wide_a,
+    input [31:0]                            wide_b,
+    output [39:0]                           wide_y,
+    // unsigned needs a spare bit to keep the sign bit of the signed MAE
+    // datapath clear, so 18 bits unsigned does not fit either
+    input [17:0]                            u18_a,
+    input [17:0]                            u18_b,
+    output [39:0]                           u18_y,
+    // a one bit operand sign extended into the adder is a decrement, not
+    // DSP work
+    input [15:0]                            flag_a,
+    input                                   flag_s,
+    output [39:0]                           flag_y,
+    // an increment: cheaper as a carry chain than as a DSP
+    output reg [23:0]                       count_y
+    );
+
+   assign wide_y = wide_a + wide_b;
+   assign u18_y  = u18_a + u18_b;
+   assign flag_y = flag_a + {18{flag_s}};
+
+   always @(posedge clk or negedge resetn) begin
+      if (~resetn) begin
+         count_y <= 'h0;
+      end
+      else begin
+         count_y <= count_y + 1'b1;
+      end
+   end
+
+endmodule
+EOF
+
+synth_fpga -partname z1010
+select -assert-count 0 */t:efpga_a*

--- a/tests/unit/dsp/mae-techmap-efpga_add_partial_pack.ys
+++ b/tests/unit/dsp/mae-techmap-efpga_add_partial_pack.ys
@@ -1,0 +1,59 @@
+# yosys -m wildebeest -s mae-techmap-efpga_add_partial_pack.ys
+#
+# Every register a MAE swallows shares the macro's single active low reset and
+# is cleared by it, so a flop that disagrees has to stay in the fabric. Both
+# adds below still reach a MAE, but in the mode without the register.
+read_verilog <<EOF
+module efpga_add_partial_pack_map_inst
+   (
+    input                                   clk,
+    input                                   resetn,
+    // 'a_reg' is on a different reset than the accumulator, so this is
+    // 'efpga_acc' and not 'efpga_acc_regi'
+    input                                   resetn2,
+    input signed [17:0]                     acc_a,
+    output reg signed [39:0]                acc_y,
+    // the output register clears to something other than zero, so this is
+    // 'efpga_adder' and not 'efpga_adder_rego'
+    input signed [17:0]                     add_a,
+    input signed [17:0]                     add_b,
+    output reg signed [39:0]                add_y
+    );
+
+   reg signed [17:0] a_reg;
+
+   always @(posedge clk or negedge resetn2) begin
+      if (~resetn2) begin
+         a_reg <= 'h0;
+      end
+      else begin
+         a_reg <= acc_a;
+      end
+   end
+
+   always @(posedge clk or negedge resetn) begin
+      if (~resetn) begin
+         acc_y <= 'h0;
+      end
+      else begin
+         acc_y <= acc_y + a_reg;
+      end
+   end
+
+   always @(posedge clk or negedge resetn) begin
+      if (~resetn) begin
+         add_y <= 40'h1;
+      end
+      else begin
+         add_y <= add_a + add_b;
+      end
+   end
+
+endmodule
+EOF
+
+synth_fpga -partname z1010
+select -assert-count 1 */t:efpga_acc
+select -assert-count 0 */t:efpga_acc_regi
+select -assert-count 1 */t:efpga_adder
+select -assert-count 0 */t:efpga_adder_rego

--- a/tests/unit/dsp/mae-techmap-efpga_adder.ys
+++ b/tests/unit/dsp/mae-techmap-efpga_adder.ys
@@ -1,0 +1,22 @@
+# yosys -m wildebeest -s mae-techmap-efpga_adder.ys
+read_verilog <<EOF
+module efpga_adder_map_inst
+  # (
+     parameter INPUT_WIDTH = 18,
+     parameter OUTPUT_WIDTH = 40
+     )
+   (
+    input signed [(INPUT_WIDTH-1):0]        a,
+    input signed [(INPUT_WIDTH-1):0]        b,
+    output signed [(OUTPUT_WIDTH-1):0]      y
+    );
+
+   assign y = a + b;
+
+endmodule
+EOF
+
+synth_fpga -partname z1010
+select -assert-count 1 */t:efpga_adder
+select -assert-count 0 */t:efpga_adder %x:+[clk] */w:clk %i
+select -assert-count 0 */t:efpga_adder %x:+[resetn] */w:resetn %i

--- a/tests/unit/dsp/mae-techmap-efpga_adder_regi.ys
+++ b/tests/unit/dsp/mae-techmap-efpga_adder_regi.ys
@@ -1,0 +1,38 @@
+# yosys -m wildebeest -s mae-techmap-efpga_adder_regi.ys
+read_verilog <<EOF
+module efpga_adder_regi_map_inst
+  # (
+     parameter INPUT_WIDTH = 18,
+     parameter OUTPUT_WIDTH = 40
+     )
+   (
+    input                                   clk,
+    input                                   resetn,
+    input signed [(INPUT_WIDTH-1):0]          a,
+    input signed [(INPUT_WIDTH-1):0]          b,
+    output signed [(OUTPUT_WIDTH-1):0]        y
+    );
+
+   reg signed [(INPUT_WIDTH-1):0] a_reg;
+   reg signed [(INPUT_WIDTH-1):0] b_reg;
+
+   always @(posedge clk or negedge resetn) begin
+      if (~resetn) begin
+         a_reg <= 'h0;
+         b_reg <= 'h0;
+      end
+      else begin
+         a_reg <= a;
+         b_reg <= b;
+      end
+   end
+
+   assign y = a_reg + b_reg;
+
+endmodule
+EOF
+
+synth_fpga -partname z1010
+select -assert-count 1 */t:efpga_adder_regi
+select -assert-count 1 */t:efpga_adder_regi %x:+[clk] */w:clk %i
+select -assert-count 1 */t:efpga_adder_regi %x:+[resetn] */w:resetn %i

--- a/tests/unit/dsp/mae-techmap-efpga_adder_regi_unsigned.ys
+++ b/tests/unit/dsp/mae-techmap-efpga_adder_regi_unsigned.ys
@@ -1,0 +1,38 @@
+# yosys -m wildebeest -s mae-techmap-efpga_adder_regi_unsigned.ys
+read_verilog <<EOF
+module efpga_adder_regi_unsigned_map_inst
+  # (
+     parameter INPUT_WIDTH = 17,
+     parameter OUTPUT_WIDTH = 40
+     )
+   (
+    input                                   clk,
+    input                                   resetn,
+    input [(INPUT_WIDTH-1):0]          a,
+    input [(INPUT_WIDTH-1):0]          b,
+    output [(OUTPUT_WIDTH-1):0]        y
+    );
+
+   reg [(INPUT_WIDTH-1):0] a_reg;
+   reg [(INPUT_WIDTH-1):0] b_reg;
+
+   always @(posedge clk or negedge resetn) begin
+      if (~resetn) begin
+         a_reg <= 'h0;
+         b_reg <= 'h0;
+      end
+      else begin
+         a_reg <= a;
+         b_reg <= b;
+      end
+   end
+
+   assign y = a_reg + b_reg;
+
+endmodule
+EOF
+
+synth_fpga -partname z1010
+select -assert-count 1 */t:efpga_adder_regi
+select -assert-count 1 */t:efpga_adder_regi %x:+[clk] */w:clk %i
+select -assert-count 1 */t:efpga_adder_regi %x:+[resetn] */w:resetn %i

--- a/tests/unit/dsp/mae-techmap-efpga_adder_regio.ys
+++ b/tests/unit/dsp/mae-techmap-efpga_adder_regio.ys
@@ -1,0 +1,45 @@
+# yosys -m wildebeest -s mae-techmap-efpga_adder_regio.ys
+read_verilog <<EOF
+module efpga_adder_regio_map_inst
+  # (
+     parameter INPUT_WIDTH = 18,
+     parameter OUTPUT_WIDTH = 40
+     )
+   (
+    input                                   clk,
+    input                                   resetn,
+    input signed [(INPUT_WIDTH-1):0]          a,
+    input signed [(INPUT_WIDTH-1):0]          b,
+    output reg signed [(OUTPUT_WIDTH-1):0]    y
+    );
+
+   reg signed [(INPUT_WIDTH-1):0] a_reg;
+   reg signed [(INPUT_WIDTH-1):0] b_reg;
+
+   always @(posedge clk or negedge resetn) begin
+      if (~resetn) begin
+         a_reg <= 'h0;
+         b_reg <= 'h0;
+      end
+      else begin
+         a_reg <= a;
+         b_reg <= b;
+      end
+   end
+
+   always @(posedge clk or negedge resetn) begin
+      if (~resetn) begin
+         y <= 'h0;
+      end
+      else begin
+         y <= a_reg + b_reg;
+      end
+   end
+
+endmodule
+EOF
+
+synth_fpga -partname z1010
+select -assert-count 1 */t:efpga_adder_regio
+select -assert-count 1 */t:efpga_adder_regio %x:+[clk] */w:clk %i
+select -assert-count 1 */t:efpga_adder_regio %x:+[resetn] */w:resetn %i

--- a/tests/unit/dsp/mae-techmap-efpga_adder_regio_unsigned.ys
+++ b/tests/unit/dsp/mae-techmap-efpga_adder_regio_unsigned.ys
@@ -1,0 +1,45 @@
+# yosys -m wildebeest -s mae-techmap-efpga_adder_regio_unsigned.ys
+read_verilog <<EOF
+module efpga_adder_regio_unsigned_map_inst
+  # (
+     parameter INPUT_WIDTH = 17,
+     parameter OUTPUT_WIDTH = 40
+     )
+   (
+    input                                   clk,
+    input                                   resetn,
+    input [(INPUT_WIDTH-1):0]          a,
+    input [(INPUT_WIDTH-1):0]          b,
+    output reg [(OUTPUT_WIDTH-1):0]    y
+    );
+
+   reg [(INPUT_WIDTH-1):0] a_reg;
+   reg [(INPUT_WIDTH-1):0] b_reg;
+
+   always @(posedge clk or negedge resetn) begin
+      if (~resetn) begin
+         a_reg <= 'h0;
+         b_reg <= 'h0;
+      end
+      else begin
+         a_reg <= a;
+         b_reg <= b;
+      end
+   end
+
+   always @(posedge clk or negedge resetn) begin
+      if (~resetn) begin
+         y <= 'h0;
+      end
+      else begin
+         y <= a_reg + b_reg;
+      end
+   end
+
+endmodule
+EOF
+
+synth_fpga -partname z1010
+select -assert-count 1 */t:efpga_adder_regio
+select -assert-count 1 */t:efpga_adder_regio %x:+[clk] */w:clk %i
+select -assert-count 1 */t:efpga_adder_regio %x:+[resetn] */w:resetn %i

--- a/tests/unit/dsp/mae-techmap-efpga_adder_rego.ys
+++ b/tests/unit/dsp/mae-techmap-efpga_adder_rego.ys
@@ -1,0 +1,31 @@
+# yosys -m wildebeest -s mae-techmap-efpga_adder_rego.ys
+read_verilog <<EOF
+module efpga_adder_rego_map_inst
+  # (
+     parameter INPUT_WIDTH = 18,
+     parameter OUTPUT_WIDTH = 40
+     )
+   (
+    input                                   clk,
+    input                                   resetn,
+    input signed [(INPUT_WIDTH-1):0]          a,
+    input signed [(INPUT_WIDTH-1):0]          b,
+    output reg signed [(OUTPUT_WIDTH-1):0]    y
+    );
+
+   always @(posedge clk or negedge resetn) begin
+      if (~resetn) begin
+         y <= 'h0;
+      end
+      else begin
+         y <= a + b;
+      end
+   end
+
+endmodule
+EOF
+
+synth_fpga -partname z1010
+select -assert-count 1 */t:efpga_adder_rego
+select -assert-count 1 */t:efpga_adder_rego %x:+[clk] */w:clk %i
+select -assert-count 1 */t:efpga_adder_rego %x:+[resetn] */w:resetn %i

--- a/tests/unit/dsp/mae-techmap-efpga_adder_rego_unsigned.ys
+++ b/tests/unit/dsp/mae-techmap-efpga_adder_rego_unsigned.ys
@@ -1,0 +1,31 @@
+# yosys -m wildebeest -s mae-techmap-efpga_adder_rego_unsigned.ys
+read_verilog <<EOF
+module efpga_adder_rego_unsigned_map_inst
+  # (
+     parameter INPUT_WIDTH = 17,
+     parameter OUTPUT_WIDTH = 40
+     )
+   (
+    input                                   clk,
+    input                                   resetn,
+    input [(INPUT_WIDTH-1):0]          a,
+    input [(INPUT_WIDTH-1):0]          b,
+    output reg [(OUTPUT_WIDTH-1):0]    y
+    );
+
+   always @(posedge clk or negedge resetn) begin
+      if (~resetn) begin
+         y <= 'h0;
+      end
+      else begin
+         y <= a + b;
+      end
+   end
+
+endmodule
+EOF
+
+synth_fpga -partname z1010
+select -assert-count 1 */t:efpga_adder_rego
+select -assert-count 1 */t:efpga_adder_rego %x:+[clk] */w:clk %i
+select -assert-count 1 */t:efpga_adder_rego %x:+[resetn] */w:resetn %i

--- a/tests/unit/dsp/mae-techmap-efpga_adder_unsigned.ys
+++ b/tests/unit/dsp/mae-techmap-efpga_adder_unsigned.ys
@@ -1,0 +1,22 @@
+# yosys -m wildebeest -s mae-techmap-efpga_adder_unsigned.ys
+read_verilog <<EOF
+module efpga_adder_unsigned_map_inst
+  # (
+     parameter INPUT_WIDTH = 17,
+     parameter OUTPUT_WIDTH = 40
+     )
+   (
+    input [(INPUT_WIDTH-1):0]        a,
+    input [(INPUT_WIDTH-1):0]        b,
+    output [(OUTPUT_WIDTH-1):0]      y
+    );
+
+   assign y = a + b;
+
+endmodule
+EOF
+
+synth_fpga -partname z1010
+select -assert-count 1 */t:efpga_adder
+select -assert-count 0 */t:efpga_adder %x:+[clk] */w:clk %i
+select -assert-count 0 */t:efpga_adder %x:+[resetn] */w:resetn %i


### PR DESCRIPTION
This adds the mix of pmgen and techmapping support needed to allow a DSP block to be used in "adder only" modes.  One thing that is not addressed is how to give priority to multipliers to use the block; this could be done in a followon pull request or by adding commits to this branch.